### PR TITLE
ビルド時にリンクオプションを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY *.go ./
-RUN CGO_ENABLED=0 go build -o /app
+RUN CGO_ENABLED=0 go build -o /app -ldflags "-s -w"
 
 # Runner
 # hadolint ignore=DL3006


### PR DESCRIPTION
## 概要
`go build` において, `-ldflags` に `-s -w` を追加することでバイナリ情報から DWARF 情報及び, デバッグ用シンボルテーブルを作らないように変更
これにより, バイナリのサイズを減らし, docker image のサイズも減少させた

## 結果
適用後: 11.9MB
適用前: 16.1MB
差分: -4.8MB (-29.8% size)

![image](https://user-images.githubusercontent.com/18034370/230919365-85a4039d-7d83-48c8-b93d-b56d1c4ebd88.png)

## 実行環境
OS: `Windows 10 21H2+build19044.2728` 
Docker: `Docker version 20.10.13, build a224086` (via Docker Desktop)